### PR TITLE
Make bash shebangs more agnostic (do not rely on hardcoded `/bin/bash`)

### DIFF
--- a/lib/misc/stdio
+++ b/lib/misc/stdio
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2021-2025, Tim Brown
 # Copyright (c) 2025, Cisco International Ltd
 #

--- a/packet-monkey.sh
+++ b/packet-monkey.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2021-2025, Tim Brown
 # Copyright (c) 2021-2025, Cisco International Ltd
 #


### PR DESCRIPTION
This PR mechanically change all the `#!/bin/bash` shebang to `#!/usr/bin/env bash` so that packet-monkey can run out of the box on operating systems that do not have bash under `/bin`.

For example, in NetBSD `bash` is usually available under `/usr/pkg/bin` but there are definitely other operating systems and possible Linux distros where bash is not under `/bin`.

Please note that I have not adjusted any `#!/bin/sh` because usually a `/bin/sh` is always available.
